### PR TITLE
Bump rust-analyzer

### DIFF
--- a/download-rust-analyzer.py
+++ b/download-rust-analyzer.py
@@ -61,7 +61,7 @@ def rust_analyzer_archive_url():
 
     ABI = abi_for_os(RUNNER_OS, libc)
     RUST_ANALYZER_ARCHIVE = ("rust-analyzer-{}-{}.gz".format(RUNNER_ARCH, ABI))
-    RUST_ANALYZER_RELEASE = "2021-11-01"
+    RUST_ANALYZER_RELEASE = "2022-03-21"
     return ("https://github.com/rust-analyzer/rust-analyzer/releases/download/{}/{}"
             .format(RUST_ANALYZER_RELEASE, RUST_ANALYZER_ARCHIVE))
 


### PR DESCRIPTION
The current release is old and doesn't emit monikers for cross repository references.

Since r-a make a release every week, we may want to get latest release from github so that we don't need constant manual updates.